### PR TITLE
Add assert.equal and assert.strictEqual

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ AssertionError: bar > 10
     at Object.oncomplete (fs.js:297:15)
 ```
 
+## assert.equal
+
+Asserts that two values are non-strictly equal (i.e. uses `==` to compare).
+
+```js
+var foo = 15, bar = "banana"
+assert.equal(foo, "15") // OK
+assert.equal(far, bar) // Throws error:
+                       // AssertionError: assert.equal: foo, bar (15 != 'banana')
+```
+
+## assert.strictEqual
+
+Asserts that two values are strictly equal (i.e. uses `===` to compare).
+
+```js
+var foo = 15, bar = "15"
+assert.strictEqual(foo, bar) // Throws error:
+                             // AssertionError: assert.strictequal: foo, bar (15 !== 15')
+```
+
 ## License (BSD)
 
 Copyright (c) 2013, Johan Sköld &lt;johan@skold.cc&gt;  

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Asserts that two values are non-strictly equal (i.e. uses `==` to compare).
 ```js
 var foo = 15, bar = "banana"
 assert.equal(foo, "15") // OK
-assert.equal(far, bar) // Throws error:
+assert.equal(foo, bar) // Throws error:
                        // AssertionError: assert.equal: foo, bar (15 != 'banana')
 ```
 


### PR DESCRIPTION
I like this library, it makes writing assertions much DRYer! But I did miss being able to assert that two things are equal and having the error message include the values of the things that were different, rather than just the names. I added an `assert.equal` and `assert.strictEqual`, and thought it might be useful to make a pull request...

I've extracted the source code extraction into a `fail` function, which takes an optional `extraMessage` parameter to give a bit more information about the error. I've only implemented `assert.equal` and `assert.strictEqual`, though I'm sure something like `assert.deepEqual` would be useful too. I've used `util.inspect` for stringifying the values.
